### PR TITLE
The Licensing.

### DIFF
--- a/Baskerville/Beta/Conduits.hs
+++ b/Baskerville/Beta/Conduits.hs
@@ -1,3 +1,16 @@
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 module Baskerville.Beta.Conduits where
 
 import qualified Data.ByteString as BS

--- a/Baskerville/Beta/Login.hs
+++ b/Baskerville/Beta/Login.hs
@@ -1,4 +1,17 @@
 {-# LANGUAGE OverloadedStrings #-}
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 
 module Baskerville.Beta.Login where
 

--- a/Baskerville/Beta/Packets.hs
+++ b/Baskerville/Beta/Packets.hs
@@ -1,3 +1,16 @@
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 module Baskerville.Beta.Packets where
 
 import Control.Applicative

--- a/Baskerville/Beta/Server.hs
+++ b/Baskerville/Beta/Server.hs
@@ -1,5 +1,18 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 
 module Baskerville.Beta.Server where
 

--- a/Baskerville/Beta/Session.hs
+++ b/Baskerville/Beta/Session.hs
@@ -1,5 +1,18 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 
 module Baskerville.Beta.Session where
 

--- a/Baskerville/Beta/Shake.hs
+++ b/Baskerville/Beta/Shake.hs
@@ -1,4 +1,17 @@
 {-# LANGUAGE OverloadedStrings #-}
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 
 module Baskerville.Beta.Shake where
 

--- a/Baskerville/Chunk.hs
+++ b/Baskerville/Chunk.hs
@@ -1,5 +1,18 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TemplateHaskell #-}
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 
 module Baskerville.Chunk where
 

--- a/Baskerville/Chunk/Generators.hs
+++ b/Baskerville/Chunk/Generators.hs
@@ -1,3 +1,16 @@
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 module Baskerville.Chunk.Generators where
 
 import Data.Array.ST

--- a/Baskerville/Coords.hs
+++ b/Baskerville/Coords.hs
@@ -1,4 +1,17 @@
 {-# LANGUAGE TemplateHaskell #-}
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 
 module Baskerville.Coords where
 

--- a/Baskerville/Location.hs
+++ b/Baskerville/Location.hs
@@ -1,4 +1,17 @@
 {-# LANGUAGE TemplateHaskell #-}
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 
 module Baskerville.Location where
 

--- a/Baskerville/Main.hs
+++ b/Baskerville/Main.hs
@@ -1,4 +1,17 @@
 {-# LANGUAGE OverloadedStrings #-}
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 
 module Main where
 

--- a/Baskerville/Simplex.hs
+++ b/Baskerville/Simplex.hs
@@ -1,3 +1,16 @@
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 module Baskerville.Simplex where
 
 import Control.Monad.Random

--- a/Baskerville/Utilities/Bits.hs
+++ b/Baskerville/Utilities/Bits.hs
@@ -1,3 +1,16 @@
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 module Baskerville.Utilities.Bits where
 
 import Data.Bits

--- a/Baskerville/Utilities/Chat.hs
+++ b/Baskerville/Utilities/Chat.hs
@@ -1,3 +1,16 @@
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 module Baskerville.Utilities.Chat where
 
 import Data.Char

--- a/Baskerville/Utilities/Control.hs
+++ b/Baskerville/Utilities/Control.hs
@@ -1,3 +1,16 @@
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 module Baskerville.Utilities.Control where
 
 import Control.Monad

--- a/Baskerville/Utilities/Geometry.hs
+++ b/Baskerville/Utilities/Geometry.hs
@@ -1,3 +1,16 @@
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 module Baskerville.Utilities.Geometry where
 
 data Coord = Coord {cx :: Float, cy :: Float, cz :: Float}

--- a/BetaTests.hs
+++ b/BetaTests.hs
@@ -1,3 +1,16 @@
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 import Char
 import Control.Monad
 import Data.Attoparsec.ByteString

--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,15 @@
 Baskerville is made available under the following terms, commonly known as the
-MIT/X11 license. Contributions from third parties are also under this license.
-
 Copyright (c) 2010-2011 Corbin Simpson et al.
+Copyright (c) 2013-2014 Google Inc.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy
+of the License at
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+http://www.apache.org/licenses/LICENSE-2.0
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.

--- a/Noiseview.hs
+++ b/Noiseview.hs
@@ -1,3 +1,16 @@
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 import Baskerville.Simplex
 import Control.Monad
 import Control.Monad.Random

--- a/PacketDump.hs
+++ b/PacketDump.hs
@@ -1,3 +1,16 @@
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 import Baskerville.Beta.Packets
 import qualified Data.ByteString as BS
 import Data.Serialize

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,15 @@
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 import Distribution.Simple
 main = defaultMain

--- a/UtilityTests.hs
+++ b/UtilityTests.hs
@@ -1,3 +1,16 @@
+-- Copyright (C) 2014 Google Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may not
+-- use this file except in compliance with the License. You may obtain a copy
+-- of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
 import Data.Bits
 import Data.Char
 import Data.List


### PR DESCRIPTION
@edunham, as discussed yesterday, please consider and approve this licensing change. It is my opinion that MIT/X11 can be upgraded into Apache 2.0 without disrupting the copyright of the original authors.
